### PR TITLE
Fix incorrect colormap alignment with 3D surface peaks

### DIFF
--- a/surfalize/plotting.py
+++ b/surfalize/plotting.py
@@ -104,7 +104,7 @@ def plot_3d(surface, vertical_angle=50, horizontal_angle=0, zoom=1, cmap='jet', 
 
     # Generate a grid of x, y values
     x = np.linspace(0, surface.width_um, surface.size.x)
-    y = np.linspace(0, surface.height_um, surface.size.y)
+    y = np.flip(np.linspace(0, surface.height_um, surface.size.y))
     x, y = np.meshgrid(x, y)
 
     # Define a mathematical function for z values
@@ -112,7 +112,7 @@ def plot_3d(surface, vertical_angle=50, horizontal_angle=0, zoom=1, cmap='jet', 
 
     # Create a PyVista grid
     grid = pv.StructuredGrid(x, y, z)
-    grid.point_data["height"] = np.rot90(z).ravel()
+    grid.point_data["height"] = z.T.ravel()
 
     # Initialize the PyVista plotter
     plotter = pv.Plotter(off_screen=not interactive, window_size=None if interactive else (1920, 1080))


### PR DESCRIPTION
I've identified that, after the latest patch (```v0.16.1```), the colormap seems to display correctly in the 2D plot but does not align with the 3D representation. With the changes proposed in this PR, this misalignment issue has been resolved.

## Problem Description

To demonstrate the issue in the current code, you can use the attached file: [Silestone_NOK.zip](https://github.com/user-attachments/files/19666426/Silestone_NOK.zip)

Run the following code:

```python
from surfalize import Surface

file='Silestone_NOK.xyz'

surface = Surface.load(file)
surface = surface.fill_nonmeasured(method='nearest')
surface_leveled = surface.level()
surface_leveled.show()
```

This will produce a 2D figure as shown below. Notice the position of the red peaks near to 0,0:

![imagen](https://github.com/user-attachments/assets/b721b295-2679-403d-9988-bc989edbb7a9)

Now, run the 3D visualization:

```python
surface_leveled.plot_3d(scale=10, interactive=True)
```

![imagen](https://github.com/user-attachments/assets/ff5a1c06-dd0c-42c9-84ed-584ea2c8077d)
![imagen](https://github.com/user-attachments/assets/cea970ec-eefa-4602-95a5-b5e4d77e280a)

In this 3D view, although the colormap appears in the right position, the peaks and valleys (blue and red areas) do not match the 2D map. Additionally, the X and Y axes are flipped, making interpretation difficult.

## Proposed Solution

With the new changes included in this PR, the result now looks like this:

![imagen](https://github.com/user-attachments/assets/a39846d8-e7eb-4873-9438-973f6d94c380)
![imagen](https://github.com/user-attachments/assets/8415dbc9-43ae-449f-800a-3967364e9184)

- the X and Y axes are displayed correctly, matching the expected Z values.

- The relief map is now properly aligned with the colormap: red hues correspond to higher peaks, and blue to deeper valleys, as expected.

- The camera is inverted, since it is oriented so that the closest point is the one corresponding to the maximum X and Y, instead of 0, 0; but I think it is not a big problem. Now the 2D and 3D maps match.